### PR TITLE
Fix FTBFS on reconfigure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ find_package(GLIB ${GLIB_MINIMUM_VERSION} REQUIRED)
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(
-    GLIB
+    GLIB_JSON
     json-glib-1.0  # what's this?
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(core)
 include_directories(
     core
     ${GLIB_INCLUDE_DIRS}
+    ${GLIB_JSON_INCLUDE_DIRS}
     ${CMAKE_BINARY_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
 )
@@ -66,7 +67,8 @@ target_link_libraries(lxqt-archiver
     Qt5::DBus
     fm-qt
     lxqt-archiver-core
-    ${GLIB_LDFLAGS}
+    ${GLIB_LIBRARIES}
+    ${GLIB_JSON_LDFLAGS}
 )
 
 install(TARGETS

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(
     ${GLIB_INCLUDE_DIRS}
+    ${GLIB_JSON_INCLUDE_DIRS}
     ${CMAKE_BINARY_DIR}
 )
 
@@ -46,14 +47,16 @@ add_library(lxqt-archiver-core STATIC
 )
 
 target_link_libraries(lxqt-archiver-core
-    ${GLIB_LDFLAGS}
+    ${GLIB_LIBRARIES}
+    ${GLIB_JSON_LDFLAGS}
 )
 
 add_executable(rpm2cpio
     commands/rpm2cpio.c
 )
 target_link_libraries(rpm2cpio
-    ${GLIB_LDFLAGS}
+    ${GLIB_LIBRARIES}
+    ${GLIB_JSON_LDFLAGS}
 )
 install(TARGETS
     rpm2cpio


### PR DESCRIPTION
The cause is a package namespace collision.
The GLIB namespace is already taken by find_package(GLIB ...).
Easy solution: Rename the pkg_check_modules(GLIB ... ) namespace.

Closes https://github.com/lxqt/lxqt-archiver/issues/73.