### PR TITLE
File DND to other apps

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(lxqt-archiver_SRCS
     passworddialog.cpp
     createfiledialog.cpp
     extractfiledialog.cpp
+    filetreeView.cpp
 )
 
 set(lxqt-archiver_UI

--- a/src/filetreeView.cpp
+++ b/src/filetreeView.cpp
@@ -1,0 +1,43 @@
+#include <QHeaderView>
+#include <QMouseEvent>
+#include <QApplication>
+
+#include "filetreeView.h"
+
+FileTreeView::FileTreeView(QWidget* parent) : QTreeView(parent) {
+    dragStarted_ = false;
+    setSelectionMode(QAbstractItemView::ExtendedSelection);
+    setIconSize(QSize(24, 24));
+    setRootIsDecorated(false);
+    setDragDropMode(QAbstractItemView::DragOnly);
+    header()->setSortIndicatorShown(true);
+    header()->setStretchLastSection(false);
+}
+
+void FileTreeView::mousePressEvent(QMouseEvent* event) {
+    QTreeView::mousePressEvent(event);
+    if (event->button() == Qt::LeftButton && indexAt(event->pos()).isValid()) {
+        dragStartPosition_ = event->pos();
+    }
+    else {
+        dragStartPosition_ = QPoint();
+    }
+    dragStarted_ = false;
+}
+
+void FileTreeView::mouseMoveEvent(QMouseEvent* event) {
+    if(dragStartPosition_.isNull()) {
+        QTreeView::mouseMoveEvent(event);
+        return;
+    }
+    if((event->pos() - dragStartPosition_).manhattanLength() >= qMax(16, QApplication::startDragDistance())) {
+        dragStarted_ = true;
+    }
+
+    if((event->buttons() & Qt::LeftButton) && dragStarted_) {
+        if(selectionModel() && !selectionModel()->selectedRows().isEmpty()) {
+            Q_EMIT dragStarted();
+        }
+        event->accept();
+    }
+}

--- a/src/filetreeView.h
+++ b/src/filetreeView.h
@@ -1,0 +1,24 @@
+#ifndef FILETREEVIEW_H
+#define FILETREEVIEW_H
+
+#include <QTreeView>
+
+class FileTreeView : public QTreeView {
+  Q_OBJECT
+
+public:
+    explicit FileTreeView(QWidget* parent = nullptr);
+
+Q_SIGNALS:
+    void dragStarted();
+
+protected:
+    virtual void mousePressEvent(QMouseEvent* event) override;
+    virtual void mouseMoveEvent(QMouseEvent* event) override;
+
+private:
+    QPoint dragStartPosition_;
+    bool dragStarted_;
+};
+
+#endif // FILETREEVIEW_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -32,6 +32,8 @@
 #include <QCheckBox>
 #include <QSpinBox>
 #include <QStandardPaths>
+#include <QDrag>
+#include <QPointer>
 
 #include <QDebug>
 
@@ -96,6 +98,7 @@ MainWindow::MainWindow(QWidget* parent):
     proxyModel_->sort(0, Qt::AscendingOrder);
 
     ui_->fileListView->setModel(proxyModel_);
+    connect(ui_->fileListView, &FileTreeView::dragStarted, this, &MainWindow::onDragStarted);
     connect(ui_->fileListView->selectionModel(), &QItemSelectionModel::selectionChanged, this, &MainWindow::onFileListSelectionChanged);
     connect(ui_->fileListView, &QAbstractItemView::activated, this, &MainWindow::onFileListActivated);
 
@@ -392,14 +395,26 @@ void MainWindow::viewSelectedFiles() {
             if(item && !item->isDir()) {
                 const QString fileName = tempDir_ + item->fullPath();
                 launchPaths_ << fileName;
-                if(archiver_->isEncrypted() && password_.empty()) {
-                    password_ = PasswordDialog::askPassword(this).toStdString();
+                if(!QFile::exists(fileName)) {
+                    if(archiver_->isEncrypted() && password_.empty()) {
+                        password_ = PasswordDialog::askPassword(this).toStdString();
+                    }
+                    files.emplace_back(item->data());
                 }
-                files.emplace_back(item->data());
             }
         }
 
-        if(!files.empty()) {
+        if(files.empty()) { // all files are already extracted; launch them together
+            if(!launchPaths_.empty()) {
+                Fm::FilePathList paths;
+                for(auto& launchPath : launchPaths_) {
+                    paths.push_back(Fm::FilePath::fromLocalPath(launchPath.toLocal8Bit().constData()));
+                }
+                Fm::FileLauncher().launchPaths(this, std::move(paths));
+                launchPaths_.clear();
+            }
+        }
+        else {
             QString dest = tempDir_;
             QDir dir(tempDir_);
             const QString curDirPath = QString::fromStdString(currentDirPath_);
@@ -424,6 +439,111 @@ void MainWindow::viewSelectedFiles() {
                                     false,
                                     password_.empty() ? nullptr : password_.c_str()
             );
+        }
+    }
+}
+
+bool MainWindow::isExtracted(const ArchiverItem* item) {
+    if(item->isDir()) {
+        std::vector<const ArchiverItem *> children;
+        item->allChildren(children);
+        if(children.empty()) {
+            const QString fileName = tempDir_ + item->fullPath();
+            return QFile::exists(fileName);
+        }
+        for(auto child : children) {
+            if(child->isDir()) {
+                if(!isExtracted(child)) {
+                    return false;
+                }
+            }
+            else {
+                const QString fileName = tempDir_ + child->fullPath();
+                if(!QFile::exists(fileName)) {
+                    return false;
+                }
+            }
+        }
+    }
+    else {
+        const QString fileName = tempDir_ + item->fullPath();
+        return QFile::exists(fileName);
+    }
+    return true;
+}
+
+void MainWindow::onDragStarted() {
+    if(tempDir_.isEmpty()) {
+        return;
+    }
+    if(auto selModel = ui_->fileListView->selectionModel()) {
+        const QString curDirPath = QString::fromStdString(currentDirPath_);
+        QStringList fileNames;
+        std::vector<const FileData*> files;
+        const QModelIndexList indexes = selModel->selectedRows();
+        for(const auto idx : indexes) {
+            if(const auto item = itemFromIndex(idx)) {
+                const QString fullPath = item->fullPath();
+                // only children of the current directory (not "..")
+                if(fullPath.startsWith(curDirPath)) {
+                    const QString fileName = tempDir_
+                                             // without the ending "/"
+                                             + (fullPath.endsWith("/") ? fullPath.left(fullPath.size() - 1)
+                                                                       : fullPath);
+                    fileNames << fileName;
+                    if(!isExtracted(item)) {
+                        if(archiver_->isEncrypted() && password_.empty()) {
+                            password_ = PasswordDialog::askPassword(this).toStdString();
+                        }
+                        files.emplace_back(item->data());
+                    }
+                }
+            }
+        }
+
+        if(!fileNames.isEmpty()) {
+            QPointer<QDrag> drag = new QDrag(this);
+            QMimeData* mimeData = new QMimeData;
+            QList<QUrl> urlList;
+            for(auto& file : fileNames) {
+                urlList << QUrl::fromLocalFile(file);
+            }
+            mimeData->setUrls(urlList);
+            drag->setMimeData(mimeData);
+            if(files.empty()) { // all files are already extracted
+                if(drag->exec(Qt::CopyAction) == Qt::IgnoreAction) {
+                    drag->deleteLater();
+                }
+            }
+            else { // wait until all files are extracted
+                connect(archiver_.get(), &Archiver::finish, this, [drag]() {
+                    if(drag && drag->exec(Qt::CopyAction) == Qt::IgnoreAction) {
+                        drag->deleteLater();
+                    }
+                });
+            }
+
+            if(!files.empty()) {
+                QString dest = tempDir_;
+                QDir dir(tempDir_);
+                if(curDirPath.contains("/")) {
+                    dest = tempDir_ + "/" + curDirPath.section("/", 0, -2);
+                    dir.mkpath(dest); // also creates "dir" if needed
+                }
+                else if(!dir.exists()) {
+                    dir.mkpath(tempDir_);
+                }
+                auto destDir = Fm::FilePath::fromLocalPath(dest.toLocal8Bit().constData());
+
+                archiver_->extractFiles(files,
+                                        destDir,
+                                        currentDirPath_.c_str(),
+                                        false,
+                                        true, // overwrite because a dir may have been only partly extracted
+                                        false,
+                                        password_.empty() ? nullptr : password_.c_str()
+                );
+            }
         }
     }
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -121,6 +121,8 @@ private Q_SLOTS:
 
     void onPropertiesFileInfoJobFinished();
 
+    void onDragStarted();
+
 private:
     void setFileName(const QString& fileName);
 
@@ -147,6 +149,8 @@ private:
     QModelIndex indexFromItem(const QModelIndex& parent, const ArchiverItem* item);
 
     void viewSelectedFiles();
+
+    bool isExtracted(const ArchiverItem* item);
 
 private:
     std::unique_ptr<Ui::MainWindow> ui_;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -56,28 +56,10 @@
         <number>0</number>
        </attribute>
       </widget>
-      <widget class="QTreeView" name="fileListView">
+      <widget class="FileTreeView" name="fileListView">
        <property name="enabled">
         <bool>false</bool>
        </property>
-       <property name="selectionMode">
-        <enum>QAbstractItemView::ExtendedSelection</enum>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-       <property name="rootIsDecorated">
-        <bool>false</bool>
-       </property>
-       <attribute name="headerShowSortIndicator" stdset="0">
-        <bool>true</bool>
-       </attribute>
-       <attribute name="headerStretchLastSection">
-        <bool>false</bool>
-       </attribute>
       </widget>
      </widget>
     </item>
@@ -428,6 +410,14 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>FileTreeView</class>
+   <extends>QTreeview</extends>
+   <header>filetreeView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt-archiver/issues/79

This is what can be done with purely Qt methods for file DND from lxqt-archiver to other apps. It supports multiple files/folders.

Its advantage is that (unlike in engrampa) dropping can happen on any app that accepts a file drop (like a text editor or an image viewer), not just on those supporting the Direct Save Protocol (XDS). As a result, for example, if a file is dropped on Desktop, it'll be positioned at the drop point.

Its drawback may be that, with huge archives, the drop (cursor) will not be ready immediately because the dragged files should be first extracted in `/tmp`. However, the progress-bar informs the user when the drop is ready. So, I think we shouldn't deprive ourselves of this DND.