### PR TITLE
Fix infinite loop on extracting an already extracted archive

### DIFF
--- a/src/core/fr-archive.c
+++ b/src/core/fr-archive.c
@@ -3192,6 +3192,11 @@ g_print("dest fn: %s\n", dest_filename);
 
 		if (extract_all)
 			path_list_free (file_list);
+
+		fr_archive_action_completed (archive,
+					     FR_ACTION_EXTRACTING_FILES,
+					     FR_PROC_ERROR_NONE,
+					     NULL);
 		return;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/lxqt-archiver/issues/103

When overwriting was disabled (like when "Extract Here" is clicked in pcmanfm-qt's context menu) and all extracted files existed, there were no signal to show that extraction was finished (without extracting anything, of course), so that the busy progressbar created an infinite loop. This patch prevents the infinite loop by emitting a signal (without error).