### PR TITLE
Prevent dropping into self

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -195,6 +195,12 @@ void MainWindow::loadFile(const Fm::FilePath &file) {
 }
 
 void MainWindow::dragEnterEvent(QDragEnterEvent *event) {
+    // If the drag is originated in this window, ignore it.
+    // This is needed when an archive contains another archive, as with deb packages.
+    if(event->source()) {
+        event->ignore();
+        return;
+    }
     if(event->mimeData()->hasUrls()) {
         const auto urlList = event->mimeData()->urls();
         if(!urlList.isEmpty()) {
@@ -212,17 +218,19 @@ void MainWindow::dragEnterEvent(QDragEnterEvent *event) {
 }
 
 void MainWindow::dropEvent(QDropEvent* event) {
-    const auto urlList = event->mimeData()->urls();
-    if(!urlList.isEmpty()) {
-        auto url = urlList.at(0);
-        if(!url.isEmpty()) {
-            auto path = Fm::FilePath::fromUri(url.toEncoded().constData());
-            if(path.hasParent()) {
-                lasrDir_ = QUrl::fromEncoded(QByteArray(path.parent().uri().get()));
+    if(event->mimeData()->hasUrls()) {
+        const auto urlList = event->mimeData()->urls();
+        if(!urlList.isEmpty()) {
+            auto url = urlList.at(0);
+            if(!url.isEmpty()) {
+                auto path = Fm::FilePath::fromUri(url.toEncoded().constData());
+                if(path.hasParent()) {
+                    lasrDir_ = QUrl::fromEncoded(QByteArray(path.parent().uri().get()));
+                }
+                loadFile(path);
+                raise();
+                activateWindow();
             }
-            loadFile(path);
-            activateWindow();
-            raise();
         }
     }
     event->acceptProposedAction();


### PR DESCRIPTION
When an item is dragged from an lxqt-archiver window, usually it cannot be dropped into it again because only archives can be dropped into lxqt-archiver windows. But some archives contain other archives (like deb packages). This patch guarantees that the items of a window are never dropped into it — although they can be dropped into another window.