### PR TITLE
24-px icons for directory tree view

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -49,6 +49,12 @@
        <property name="sizeAdjustPolicy">
         <enum>QAbstractScrollArea::AdjustIgnored</enum>
        </property>
+       <property name="iconSize">
+        <size>
+         <width>24</width>
+         <height>24</height>
+        </size>
+       </property>
        <attribute name="headerVisible">
         <bool>false</bool>
        </attribute>


### PR DESCRIPTION
The file view icon size is already 24px.

Better not leave these sizes to the style. In future, they could be made configurable.