### PR TITLE
 file-utils.c: prevent memory leak

### DIFF
--- a/src/core/file-utils.c
+++ b/src/core/file-utils.c
@@ -944,7 +944,9 @@ get_temp_work_dir (const char *parent_folder)
 		g_free (template);
 		result = NULL;
 	}
-
+	
+	g_free(best_folder);
+	
 	return result;
 }
 


### PR DESCRIPTION
It was not dangerous as the string doesn't take much memory