### PR TITLE
Fix clumun of "Modified"(modifiedTime)

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -938,7 +938,7 @@ QList<QStandardItem *> MainWindow::createFileListRow(const ArchiverItem *file) {
     }
 
     // mtime
-    auto mtime = QDateTime::fromMSecsSinceEpoch(file->modifiedTime() * 1000);
+    auto mtime = QDateTime::fromMSecsSinceEpoch((long long)file->modifiedTime() * 1000);
 
     // FIXME: filename might not be UTF-8
     QString name = viewMode_ == ViewMode::FlatList ? QString::fromUtf8(file->fullPath()) : QString::fromUtf8(file->name());


### PR DESCRIPTION
My PC is 32bit CPU. This may be related.

I added "(long long)".  
I have a little C skill, but I don't have C++ skill. I don't know if the fix is the best.

### Screenshot

Before:
![screen-lxqt-archiver-before-A](https://user-images.githubusercontent.com/52656419/65512254-d1dff980-df13-11e9-9e12-3201f8e3b5d6.jpg)


After:
![screen-lxqt-archiver-after-A](https://user-images.githubusercontent.com/52656419/65512273-d99f9e00-df13-11e9-8747-0c4053ff83d1.jpg)


### System Information
* Distribution & Version: Ubuntu 18.04.3 LTS (i686)
* Kernel: 4.15.0-64-generic
* Qt Version: 5.9.5
* Package version: build from source
