### PR TITLE
Use qint64 for modification time

### DIFF
--- a/src/archiveritem.cpp
+++ b/src/archiveritem.cpp
@@ -38,8 +38,8 @@ const char *ArchiverItem::fullPath() const {
 }
 
 
-time_t ArchiverItem::modifiedTime() const {
-    return data_ ? data_->modified : 0;
+qint64 ArchiverItem::modifiedTime() const {
+    return data_ ? static_cast<quint64>(data_->modified) : 0LL; // data_->modified is time_t
 }
 
 size_t ArchiverItem::size() const {

--- a/src/archiveritem.h
+++ b/src/archiveritem.h
@@ -25,7 +25,7 @@ public:
 
     const char* fullPath() const;
 
-    time_t modifiedTime() const;
+    qint64 modifiedTime() const;
 
     size_t size() const;
 


### PR DESCRIPTION
Because `time_t` is a 32-bit integer under 32-bit systems.