### PR TITLE
CMake: Use 'LIBEXECDIR' instead of 'LIBDIR' for executables

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -5,8 +5,8 @@ include_directories(
 )
 
 add_definitions(
-    -DSHDIR=\"${CMAKE_INSTALL_LIBDIR}/lxqt-archiver\"
-    -DPRIVEXECDIR=\"${CMAKE_INSTALL_LIBDIR}/lxqt-archiver\"
+    -DSHDIR=\"${CMAKE_INSTALL_LIBEXECDIR}/lxqt-archiver\"
+    -DPRIVEXECDIR=\"${CMAKE_INSTALL_LIBEXECDIR}/lxqt-archiver\"
 )
 
 add_library(lxqt-archiver-core STATIC
@@ -60,7 +60,7 @@ target_link_libraries(rpm2cpio
 )
 install(TARGETS
     rpm2cpio
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/lxqt-archiver"
+    DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/lxqt-archiver"
     COMPONENT Runtime
 )
 
@@ -71,6 +71,6 @@ set(SCRIPT_FILES
 
 install(FILES
     ${SCRIPT_FILES}
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/lxqt-archiver"
+    DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/lxqt-archiver"
     COMPONENT Runtime
 )


### PR DESCRIPTION
While packaging the first release for Gentoo Linux, we noticed that 'rpm2cpio' and 'isoinfo.sh' were being installed under '/usr/lib64', while '/usr/libexec' seems like a more natural-like choice.

Thanks!
