### PR TITLE
CMake: Remove unused qtdbus dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ set(CMAKE_AUTOUIC ON)
 include(GNUInstallDirs)
 
 
-find_package(Qt5DBus ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5Widgets ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5X11Extras ${QT_MINIMUM_VERSION} REQUIRED)  # seems to be required by fm-qt?

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,7 +65,6 @@ target_compile_definitions(lxqt-archiver
 
 target_link_libraries(lxqt-archiver
     Qt5::Widgets
-    Qt5::DBus
     fm-qt
     lxqt-archiver-core
     ${GLIB_LIBRARIES}


### PR DESCRIPTION
I could not find this being linked to, or used in any way.  Building and running without it seems to work fine as far as I tested.

Is it really required?

Thanks!
