### PR TITLE
Remove comment about json-glib in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(
     GLIB_JSON
-    json-glib-1.0  # what's this?
+    json-glib-1.0
 )
 
 set(LXQT_ARCHIVER_MAJOR_VERSION 0)


### PR DESCRIPTION
jsong-glib is used in src/core/fr-command-unarchiver.c