### PR TITLE
Fix build with GCC 10

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,8 +52,6 @@
 #include <string>
 #include <unordered_map>
 
-gint          ForceDirectoryCreation;
-
 static char** remaining_args;
 static char*  add_to = nullptr;
 static int    add;


### PR DESCRIPTION
GCC 10 defaults to '-fno-common' [1], which triggers issues with
defining global variables multiple times.  To fix the build, use
'extern' to turn the first definition of 'ForceDirectoryCreation'
into a declaration.

1. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678
