### PR TITLE
Avoid memory leak in java utils

### DIFF
--- a/src/core/java-utils.c
+++ b/src/core/java-utils.c
@@ -310,7 +310,9 @@ get_package_name_from_class_file (char *fname)
 		for (i = length; (i >= 0) && (end == 0); i-- )
 			if (package[i] == '/')
 				end = i;
-		package = g_strndup (package, end);
+                char *package_padded = g_strndup (package, end);
+                g_free(package);
+                package = package_padded;
 	}
 
 	java_class_file_free (cfile);


### PR DESCRIPTION
`g_strndup` allocated the memory for the second time without releasing it
I understand my way of fixing the issue is not perfect so I'd love to hear your suggestions on it