### PR TITLE
comparison of integer expressions of different signedness: ‘size_t’

### DIFF
--- a/src/core/fr-archive.c
+++ b/src/core/fr-archive.c
@@ -566,8 +566,8 @@ get_mime_type_from_magic_numbers (GFile *file)
 		{ 0,  4, "LRZI",                                 "application/x-lrzip"         },
 	};
 
-	char buffer[32];
-	int  i;
+	char   buffer[32];
+	size_t i;
 
 	if (! g_load_file_in_buffer (file, buffer, sizeof (buffer), NULL))
 		return NULL;

--- a/src/core/fr-command-tar.c
+++ b/src/core/fr-command-tar.c
@@ -1110,8 +1110,8 @@ fr_command_tar_get_capabilities (FrCommand  *comm,
 			capabilities |= FR_COMMAND_CAN_READ_WRITE;
 	}
 	else if (is_mime_type (mime_type, "application/x-7z-compressed-tar")) {
-		char *try_command[3] = { "7za", "7zr", "7z" };
-		int   i;
+		char  *try_command[3] = { "7za", "7zr", "7z" };
+		size_t i;
 
 		for (i = 0; i < G_N_ELEMENTS (try_command); i++) {
 			if (is_program_available (try_command[i], check_command)) {
@@ -1134,8 +1134,8 @@ fr_command_tar_set_mime_type (FrCommand  *comm,
 	FR_COMMAND_CLASS (parent_class)->set_mime_type (comm, mime_type);
 
 	if (is_mime_type (mime_type, "application/x-7z-compressed-tar")) {
-		char *try_command[3] = { "7za", "7zr", "7z" };
-		int   i;
+		char  *try_command[3] = { "7za", "7zr", "7z" };
+		size_t i;
 
 		for (i = 0; i < G_N_ELEMENTS (try_command); i++) {
 			if (is_program_in_path (try_command[i])) {

--- a/src/core/gio-utils.c
+++ b/src/core/gio-utils.c
@@ -522,7 +522,7 @@ get_dir_list_from_file_list (GHashTable *h_dirs,
 {
 	GList *scan;
 	GList *dir_list = NULL;
-	int    base_dir_len;
+	size_t base_dir_len;
 
 	if (base_dir == NULL)
 		base_dir = "";

--- a/src/core/glib-utils.c
+++ b/src/core/glib-utils.c
@@ -744,7 +744,7 @@ _g_path_get_base_name (const char *path,
 		       const char *base_dir,
 		       gboolean    junk_paths)
 {
-	int         base_dir_len;
+	size_t      base_dir_len;
 	const char *base_path;
 
 	if (junk_paths)


### PR DESCRIPTION
Refer https://github.com/lxqt/lxqt-archiver/issues/180, https://github.com/mate-desktop/engrampa/pull/288