### PR TITLE
fix compilation error with hardened security flags

### DIFF
--- a/src/core/fr-archive.c
+++ b/src/core/fr-archive.c
@@ -1244,7 +1244,7 @@ copy_remote_file (FrArchive  *archive,
 	if (! g_file_query_exists (archive->file, archive->priv->cancellable)) {
 		GError *error;
 
-        error = g_error_new (G_IO_ERROR, G_IO_ERROR_NOT_FOUND, _("Archive not found"));
+        error = g_error_new_literal (G_IO_ERROR, G_IO_ERROR_NOT_FOUND, _("Archive not found"));
 		fr_archive_copy_done (archive, FR_ACTION_LOADING_ARCHIVE, error);
 		g_error_free (error);
 


### PR DESCRIPTION
When building with '-Wformat -Wformat-security -Werror=format-security' the
following error is spawned:

| <..>/git/src/core/fr-archive.c:1247:9: error: format not a string literal and no format arguments [-Werror=format-security]
|  1247 |         error = g_error_new (G_IO_ERROR, G_IO_ERROR_NOT_FOUND, _("Archive not found"));
|       |         ^~~~~
| cc1: some warnings being treated as errors

Received this patch within [1] and reworked commit message

Thanks to: Clara Scherer <clara.scherer@avnet.eu>

[1] https://github.com/schnitzeltony/meta-qt5-extra/pull/80

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>