### PR TITLE
Made directory view horizontally scrollable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(lxqt-archiver_SRCS
     createfiledialog.cpp
     extractfiledialog.cpp
     filetreeView.cpp
+    dirtreeView.cpp
 )
 
 set(lxqt-archiver_UI

--- a/src/dirtreeView.cpp
+++ b/src/dirtreeView.cpp
@@ -1,0 +1,38 @@
+#include <QHeaderView>
+#include <QScrollBar>
+#include <QApplication>
+
+#include "dirtreeView.h"
+
+DirTreeView::DirTreeView(QWidget* parent) : QTreeView(parent) {
+    setIconSize(QSize(24, 24));
+    header()->setOffset(0);
+    setHeaderHidden(true);
+    // show the horizontal scrollbar if needed
+    header()->setStretchLastSection(false);
+    header()->setSectionResizeMode(QHeaderView::ResizeToContents);
+}
+
+// Ensure that the item is visible horizontally too (Qt's default behavior is buggy).
+void DirTreeView::scrollTo(const QModelIndex &index, QAbstractItemView::ScrollHint hint) {
+    QTreeView::scrollTo (index, hint);
+    if (index.isValid())
+    {
+        int viewportWidth = viewport()->width();
+        QRect vr = visualRect (index);
+        int itemWidth = vr.width() + indentation();
+        int hPos;
+        if (QApplication::layoutDirection() == Qt::RightToLeft) {
+            hPos = viewportWidth - vr.x() - vr.width() - indentation(); // horizontally mirrored
+        }
+        else {
+            hPos = vr.x() - indentation();
+        }
+        if (hPos < 0 || itemWidth > viewportWidth) {
+            horizontalScrollBar()->setValue (hPos);
+        }
+        else if (hPos + itemWidth > viewportWidth) {
+            horizontalScrollBar()->setValue (hPos + itemWidth - viewportWidth);
+        }
+    }
+}

--- a/src/dirtreeView.h
+++ b/src/dirtreeView.h
@@ -1,0 +1,15 @@
+#ifndef DIRTREEVIEW_H
+#define DIRTREEVIEW_H
+
+#include <QTreeView>
+
+class DirTreeView : public QTreeView {
+  Q_OBJECT
+
+public:
+    explicit DirTreeView(QWidget* parent = nullptr);
+
+    void scrollTo(const QModelIndex &index, QAbstractItemView::ScrollHint hint = QAbstractItemView::EnsureVisible) override;
+};
+
+#endif // DIRTREEVIEW_H

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1120,7 +1120,7 @@ QModelIndex MainWindow::indexFromItem(const QModelIndex &parent, const ArchiverI
         auto model = parent.model();
         auto n_rows = model->rowCount(parent);
         for(int row = 0; row < n_rows; ++row) {
-            auto rowIdx = parent.child(row, 0);
+            auto rowIdx = model->index(row, 0, parent);
             if(itemFromIndex(rowIdx) == item) {
                 index = std::move(rowIdx);
                 break;

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -36,7 +36,7 @@
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
-      <widget class="QTreeView" name="dirTreeView">
+      <widget class="DirTreeView" name="dirTreeView">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -46,21 +46,6 @@
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="sizeAdjustPolicy">
-        <enum>QAbstractScrollArea::AdjustIgnored</enum>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>24</width>
-         <height>24</height>
-        </size>
-       </property>
-       <attribute name="headerVisible">
-        <bool>false</bool>
-       </attribute>
-       <attribute name="headerDefaultSectionSize">
-        <number>0</number>
-       </attribute>
       </widget>
       <widget class="QWidget" name="verticalLayoutWidget">
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -472,6 +457,12 @@
    <class>FileTreeView</class>
    <extends>QTreeview</extends>
    <header>filetreeView.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>DirTreeView</class>
+   <extends>QTreeview</extends>
+   <header>dirtreeView.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>


### PR DESCRIPTION
That's more practical than eliding.

Note: Qt has an old bug about the horizontal visibility of items when they are selected. The patch includes a workaround, so that the horizontal scrollbar is automatically and appropriately adjusted whenever the selection changes.

Closes https://github.com/lxqt/lxqt-archiver/issues/233