### PR TITLE
Remove duplicated assignment

### DIFF
--- a/src/core/fr-archive.c
+++ b/src/core/fr-archive.c
@@ -1926,7 +1926,6 @@ copy_remote_files (FrArchive     *archive,
 	xfer_data->base_uri = g_strdup (base_uri);
 	xfer_data->dest_dir = g_strdup (dest_dir);
 	xfer_data->update = update;
-	xfer_data->dest_dir = g_strdup (dest_dir);
 	xfer_data->password = g_strdup (password);
 	xfer_data->encrypt_header = encrypt_header;
 	xfer_data->compression = compression;


### PR DESCRIPTION
Backported from mate-desktop/engrampa#410.
Closes #176.