### PR TITLE
Open Recent menu

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -316,18 +316,6 @@ void MainWindow::addToRecentFiles(const Fm::FilePath &file) {
     auto name = QString::fromUtf8(file.baseName().get());
     auto path = QString::fromUtf8(file.uri().get());
     bool isMoved = false;
-//    QListIterator<recentFile> it(recentFiles_);
-//    while(it.hasNext()) {
-//        qDebug() << it.next().name << it.next().path;
-//        qDebug() << it.next().name << it.next().path;
-//        if (it.next().path == path) {
-//            recentFiles_.insert(0, recentFiles_.takeAt(recentFiles_.indexOf(it.next())));
-//            isMoved = true;
-//        }
-//        qDebug() << it.next().name << it.next().path;
-//        qDebug() << it.next().name << it.next().path;
-//    }
-
     for (auto file : recentFiles_) {
         if (file.path == path) {
             recentFiles_.insert(0, recentFiles_.takeAt(recentFiles_.indexOf(file)));

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -3,6 +3,7 @@
 
 #include <QMainWindow>
 #include <QObject>
+#include <QString>
 #include <memory>
 #include <vector>
 #include <string>
@@ -22,6 +23,17 @@ class QLineEdit;
 class QMenu;
 class ArchiverProxyModel;
 
+
+struct recentFile
+{
+    QString name;
+    QString path;
+
+    bool operator==(const recentFile &rf) const
+    {
+        return (name == rf.name && path == rf.path);
+    }
+};
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
@@ -202,7 +214,14 @@ private:
 
     int splitterPos_;
 
-    QStringList recentFiles_;
+    QList<recentFile> recentFiles_;
 };
+
+
+QDataStream &operator<<(QDataStream &out, const recentFile &rf);
+
+QDataStream &operator>>(QDataStream &in, recentFile &rf);
+
+Q_DECLARE_METATYPE(recentFile);
 
 #endif // MAINWINDOW_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -100,6 +100,8 @@ private Q_SLOTS:
 
     void on_actionFilter_triggered(bool checked);
 
+    void onRecentClearAction(bool checked);
+
     void onDirTreeSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
 
     void onFileListSelectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
@@ -113,6 +115,8 @@ private Q_SLOTS:
     void onFileListEnterPressed();
 
     void onViewsIconSizeTtriggered(QAction *action);
+
+    void onRecentFileAction(QAction *action);
 
     void filter(const QString& text);
 
@@ -172,6 +176,10 @@ private:
 
     bool isExtracted(const ArchiverItem* item);
 
+    void updateRecentFilesSubMenu();
+
+    void addToRecentFiles(const Fm::FilePath &file);
+
 private:
     std::unique_ptr<Ui::MainWindow> ui_;
     std::shared_ptr<Archiver> archiver_;
@@ -193,6 +201,8 @@ private:
     QUrl lasrDir_;
 
     int splitterPos_;
+
+    QStringList recentFiles_;
 };
 
 #endif // MAINWINDOW_H

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -82,8 +82,17 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <widget class="QMenu" name="menuOpen_Recent">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>Open &amp;Recent</string>
+     </property>
+    </widget>
     <addaction name="actionCreateNew"/>
     <addaction name="actionOpen"/>
+    <addaction name="menuOpen_Recent"/>
     <addaction name="actionSaveAs"/>
     <addaction name="separator"/>
     <addaction name="actionExtract"/>


### PR DESCRIPTION
Here is support for open recent files in Gui.

No idea how to get file name (baseName) code from path.
```
        //fixme wtf is this?
        QString name = QString::fromUtf8(Fm::FilePath::fromUri(QUrl(path).toEncoded().constData()).baseName().get());
```
Original idea was to use `QHash<QString, QVariant>` to store path as a key and fileName as value. To avoid using QFileInfo for file names. As QFileInfo will basically wake up parked/slow hard drives and do unnecessary network filesystems requests.

But still retrieving file name from path on every program start is a bad idea, for example local/network filesystem can be not mounted at all. I give up on qhash because in qt 5.15 they deprecated backward itterator https://doc.qt.io/qt-5/qhashiterator-obsolete.html