### PR TITLE
Forget previous password (if any) on reloading archive

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -725,6 +725,7 @@ void MainWindow::on_actionReload_triggered(bool /*checked*/) {
         if(!tempDir_.isEmpty()) { // remove the last temp dir
             QDir(tempDir_).removeRecursively();
         }
+        password_.clear();
         archiver_->reloadArchive(nullptr);
     }
 }


### PR DESCRIPTION
Otherwise, if the archive has an encrypted list, no password dialog will be shown again and the archive won't be opened.