### PR TITLE
Port away from deprecated time format

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -21,6 +21,7 @@
 #include <QDateTime>
 #include <QProgressBar>
 #include <QLabel>
+#include <QLocale>
 #include <QTextCodec>
 #include <QActionGroup>
 #include <QLineEdit>
@@ -1039,7 +1040,7 @@ QList<QStandardItem *> MainWindow::createFileListRow(const ArchiverItem *file) {
     sizeItem->setData(QStringLiteral("size"), ArchiverItemRole);
     sizeItem->setEditable(false);
 
-    auto mtimeItem = new QStandardItem{mtime.toString(Qt::SystemLocaleShortDate)};
+    auto mtimeItem = new QStandardItem(QLocale::system().toString(mtime, QLocale::ShortFormat));
     mtimeItem->setData(QStringLiteral("mTime"), ArchiverItemRole);
     mtimeItem->setEditable(false);
 


### PR DESCRIPTION
Using:
QString QLocale::toString(const QDate &date, QLocale::FormatType format = LongFormat)
Introduced int Qt 4.5.
