### PR TITLE
No directory change in file list by right clicking

### DIFF
--- a/src/filetreeView.cpp
+++ b/src/filetreeView.cpp
@@ -27,6 +27,18 @@ void FileTreeView::mousePressEvent(QMouseEvent* event) {
     dragStarted_ = false;
 }
 
+void FileTreeView::mouseReleaseEvent(QMouseEvent* event)
+{
+    // Do not activate by right clicking because
+    // context menus may be shown on releasing right mouse button.
+    if(event->button() == Qt::RightButton) {
+        event->ignore();
+        return;
+    }
+
+    QTreeView::mouseReleaseEvent(event);
+}
+
 void FileTreeView::mouseMoveEvent(QMouseEvent* event) {
     if(dragStartPosition_.isNull()) {
         QTreeView::mouseMoveEvent(event);

--- a/src/filetreeView.h
+++ b/src/filetreeView.h
@@ -15,6 +15,7 @@ Q_SIGNALS:
 
 protected:
     virtual void mousePressEvent(QMouseEvent* event) override;
+    virtual void mouseReleaseEvent(QMouseEvent* event) override;
     virtual void mouseMoveEvent(QMouseEvent* event) override;
     virtual void keyPressEvent(QKeyEvent* event) override;
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1040,7 +1040,7 @@ QList<QStandardItem *> MainWindow::createFileListRow(const ArchiverItem *file) {
     sizeItem->setData(QStringLiteral("size"), ArchiverItemRole);
     sizeItem->setEditable(false);
 
-    auto mtimeItem = new QStandardItem(QLocale::system().toString(mtime, QLocale::ShortFormat));
+    auto mtimeItem = new QStandardItem(locale().toString(mtime, QLocale::ShortFormat));
     mtimeItem->setData(QStringLiteral("mTime"), ArchiverItemRole);
     mtimeItem->setEditable(false);
 


### PR DESCRIPTION
See https://github.com/lxqt/lxqt/discussions/2460 and https://github.com/lxqt/lxqt-qtplugin/pull/79 for the reason. It doesn't affect the default behavior.

Also, used the widget's locale instead of system locale.