### PR TITLE
Added fallback icons to toolbar and menu

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -80,6 +80,14 @@ MainWindow::MainWindow(QWidget* parent):
     viewModeGroup->addAction(ui_->actionDirTreeMode);
     viewModeGroup->addAction(ui_->actionFlatListMode);
 
+    // icons are set here for having fallbacks
+    ui_->actionExtract->setIcon(QIcon::fromTheme(QStringLiteral("archive-extract"),
+                                                 QIcon::fromTheme(QStringLiteral("go-up"))));
+    ui_->actionAddFiles->setIcon(QIcon::fromTheme(QStringLiteral("archive-insert"),
+                                                  QIcon::fromTheme(QStringLiteral("insert-object"))));
+    ui_->actionAddFolder->setIcon(QIcon::fromTheme(QStringLiteral("archive-insert-directory"),
+                                                   QIcon::fromTheme(QStringLiteral("insert-object"))));
+
     // views icon size
     auto viewsIconSizeGroup = new QActionGroup{this};
     ui_->action16px->setData(16);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -222,10 +222,6 @@
    </property>
   </action>
   <action name="actionExtract">
-   <property name="icon">
-    <iconset theme="archive-extract">
-     <normaloff>.</normaloff>.</iconset>
-   </property>
    <property name="text">
     <string>&amp;Extract</string>
    </property>
@@ -333,19 +329,11 @@
    </property>
   </action>
   <action name="actionAddFiles">
-   <property name="icon">
-    <iconset theme="archive-insert">
-     <normaloff>.</normaloff>.</iconset>
-   </property>
    <property name="text">
     <string>&amp;Add Files</string>
    </property>
   </action>
   <action name="actionAddFolder">
-   <property name="icon">
-    <iconset theme="archive-insert-directory">
-     <normaloff>.</normaloff>.</iconset>
-   </property>
    <property name="text">
     <string>Add F&amp;older</string>
    </property>


### PR DESCRIPTION
for non rich icon sets which don't include icons not listed in the Freedesktop standard icon name list.

Note (in the comments) that I had no way to check if the current icons set in the UI were created successfully, but I haven't modified the ui file, so what is better, removing and leave the code as is or test one icon? E.g.:

```cpp
QIcon icon = QIcon::fromTheme(QStringLiteral("archive-extract"));
if (icon.isNull()) {
   ui_->actionExtract->setIcon(QStringLiteral("go-up"));
   ui_->actionAddFiles->setIcon(QStringLiteral("insert-object"));
   // ...
}
```
Closes #368
