### PR TITLE
Support use of 7zip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,10 @@ project(lxqt-archiver)
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 
+option(USE_7Z "Building with 7z" OFF)
+if(USE_7Z)
+    add_definitions(-DUSE_7Z)
+endif()
 
 set(GLIB_MINIMUM_VERSION "2.50.0")
 set(LIBFMQT_MINIMUM_VERSION "1.4.0")

--- a/src/core/fr-command-7z.c
+++ b/src/core/fr-command-7z.c
@@ -345,7 +345,10 @@ fr_command_7z_add (FrCommand     *comm,
 	if (spd_support) fr_process_add_arg (comm->process, "-spd");
 	fr_process_add_arg (comm->process, "-bd");
 	fr_process_add_arg (comm->process, "-y");
+#ifndef USE_7Z
+	Unlike p7zip, 7zip does not support '-l'. Define USE_7Z to disable '-l'. */
 	fr_process_add_arg (comm->process, "-l");
+#endif
 	add_password_arg (comm, comm->password, FALSE);
 	if ((comm->password != NULL)
 	    && (*comm->password != 0)


### PR DESCRIPTION
Debian and Ubuntu are now using 7zip instead of p7zip. With 7zip the archieve creation fails as it does not support '-l'. This change will disable '-l' if anyone defines USE_7Z in the build flags. Other builds who have not defined 'USE_7Z' are not affected.

Closes: https://github.com/lxqt/lxqt-archiver/issues/379