### PR TITLE
Add clearButtonEnabled property to filter bar

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -61,6 +61,9 @@
           <property name="placeholderText">
            <string>Filter Files...</string>
           </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
        </layout>


### PR DESCRIPTION
Same as https://github.com/lxqt/lxqt-panel/pull/1898

----

Unrelated, while compiling there's a GLib cast warning:
```
[ 40%] Building CXX object src/CMakeFiles/lxqt-archiver.dir/archiver.cpp.o
lxqt-archiver/src/archiver.cpp: In static member function ‘static void Archiver::freeStrsGList(GList*)’:
lxqt-archiver/src/archiver.cpp:355:26: warning: cast between incompatible function types from ‘void (*)(gpointer)’ {aka ‘void (*)(void*)’} to ‘GFunc’ {aka ‘void (*)(void*, void*)’} [-Wcast-function-type]
  355 |     g_list_foreach(strs, (GFunc)g_free, nullptr);
      |
```