### PR TITLE
Build with 7zip by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project(lxqt-archiver)
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 
-option(USE_7Z "Building with 7zip instead of p7zip" OFF)
+option(USE_7Z "Building with 7zip" ON)
 if(USE_7Z)
     add_definitions(-DUSE_7Z)
 endif()


### PR DESCRIPTION
Because `p7zip` is frowned on by main distros.

`USE_7Z` can still be set to `OFF` for compilation against `p7zip`.

Closes https://github.com/lxqt/lxqt-archiver/issues/411