### PR TITLE
Show targets of link items

### DIFF
--- a/src/archiveritem.cpp
+++ b/src/archiveritem.cpp
@@ -37,6 +37,9 @@ const char *ArchiverItem::fullPath() const {
     return data_ ? data_->full_path : nullptr;
 }
 
+const char *ArchiverItem::link() const {
+    return data_ ? data_->link : nullptr;
+}
 
 qint64 ArchiverItem::modifiedTime() const {
     return data_ ? static_cast<quint64>(data_->modified) : 0LL; // data_->modified is time_t

--- a/src/archiveritem.h
+++ b/src/archiveritem.h
@@ -25,6 +25,8 @@ public:
 
     const char* fullPath() const;
 
+    const char* link() const;
+
     qint64 modifiedTime() const;
 
     size_t size() const;

--- a/src/filetreeView.cpp
+++ b/src/filetreeView.cpp
@@ -14,6 +14,9 @@ FileTreeView::FileTreeView(QWidget* parent) : QTreeView(parent) {
     header()->setStretchLastSection(false);
     header()->setSortIndicatorShown(true);
     header()->setSortIndicator(0, Qt::AscendingOrder);
+    // NOTE:This not only enables optimizations, but it also prevents wrong
+    // heights if the view is scrolled while the first column is not visible.
+    setUniformRowHeights(true);
 }
 
 void FileTreeView::mousePressEvent(QMouseEvent* event) {

--- a/src/filetreeView.h
+++ b/src/filetreeView.h
@@ -14,9 +14,9 @@ Q_SIGNALS:
     void enterPressed();
 
 protected:
-    virtual void mousePressEvent(QMouseEvent* event) override;
-    virtual void mouseMoveEvent(QMouseEvent* event) override;
-    virtual void keyPressEvent(QKeyEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void keyPressEvent(QKeyEvent* event) override;
 
 private:
     QPoint dragStartPosition_;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1026,6 +1026,9 @@ QList<QStandardItem *> MainWindow::createFileListRow(const ArchiverItem *file) {
     if(mimeType) {
         auto iconInfo = mimeType->icon();
         desc = QString::fromUtf8(mimeType->desc());
+        if(auto link = file->link()) {
+            desc += QStringLiteral(" (%1)").arg(tr("Link to") + QChar(QChar::Space) + QString::fromUtf8(link));
+        }
         if(iconInfo) {
             icon = iconInfo->qicon();
         }
@@ -1036,7 +1039,7 @@ QList<QStandardItem *> MainWindow::createFileListRow(const ArchiverItem *file) {
 
     // FIXME: filename might not be UTF-8
     QString name = viewMode_ == ViewMode::FlatList ? QString::fromUtf8(file->fullPath()) : QString::fromUtf8(file->name());
-    auto nameItem = new QStandardItem{icon, name};
+    auto nameItem = new QStandardItem{icon, name.simplified()}; // no newline (fixed height)
     nameItem->setData(QVariant::fromValue(file), ArchiverItemRole); // store the item pointer on the first column
     nameItem->setEditable(false);
 


### PR DESCRIPTION
Now the targets of link items appear in the "File Type" column, inside parentheses.

Closes https://github.com/lxqt/lxqt-archiver/issues/89