### PR TITLE
Check `QPointer<QDrag>` for nullity before calling `deleteLater()` on it

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -658,13 +658,13 @@ void MainWindow::onDragStarted() {
             mimeData->setUrls(urlList);
             drag->setMimeData(mimeData);
             if(files.empty()) { // all files are already extracted
-                if(drag->exec(Qt::CopyAction) == Qt::IgnoreAction) {
+                if(drag->exec(Qt::CopyAction) == Qt::IgnoreAction && drag) {
                     drag->deleteLater();
                 }
             }
             else { // wait until all files are extracted
                 connect(archiver_.get(), &Archiver::finish, drag, [drag]() {
-                    if(drag->exec(Qt::CopyAction) == Qt::IgnoreAction) {
+                    if(drag->exec(Qt::CopyAction) == Qt::IgnoreAction && drag) {
                         drag->deleteLater();
                     }
                 });


### PR DESCRIPTION
They say that, otherwise, a crash will be imminent with Clang's optimizations enabled. So, better safe than sorry.