### PR TITLE
Fixed "Re-create folders" on extraction

### DIFF
--- a/src/extract.ui
+++ b/src/extract.ui
@@ -64,6 +64,9 @@
         <property name="text">
          <string>Re-create folders</string>
         </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
        </widget>
       </item>
       <item>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -142,7 +142,7 @@ static int runApp(QApplication& app) {
 
     bool extractSkipOlder = false;
     bool extractOverwrite = false;
-    bool extractReCreateFolders = false;
+    bool extractReCreateFolders = true; // recreate folders by default
 
     if(extract_to != nullptr) {
         extract_to_uri = get_uri_from_command_line(extract_to);
@@ -310,7 +310,7 @@ static int runApp(QApplication& app) {
                     if(extract_here) {
                         archiver.extractHere(extractSkipOlder,
                                              extractOverwrite,
-                                             extractReCreateFolders,
+                                             !extractReCreateFolders,
                                              password_.empty() ? nullptr : password_.c_str());
                     }
                     else {
@@ -318,7 +318,7 @@ static int runApp(QApplication& app) {
                         archiver.extractAll(extract_to_uri,
                                             extractSkipOlder,
                                             extractOverwrite,
-                                            extractReCreateFolders,
+                                            !extractReCreateFolders,
                                             password_.empty() ? nullptr : password_.c_str());
                     }
                     break;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -505,7 +505,7 @@ void MainWindow::on_actionExtract_triggered(bool /*checked*/) {
             archiver_->extractAll(dirUrl.toEncoded().constData(),
                                   dlg.skipOlder(),
                                   dlg.overwrite(),
-                                  dlg.reCreateFolders(),
+                                  !dlg.reCreateFolders(),
                                   password_.empty() ? nullptr : password_.c_str());
         }
         else {
@@ -521,7 +521,7 @@ void MainWindow::on_actionExtract_triggered(bool /*checked*/) {
                                     currentDirPath_.c_str(),
                                     dlg.skipOlder(),
                                     dlg.overwrite(),
-                                    dlg.reCreateFolders(),
+                                    !dlg.reCreateFolders(),
                                     password_.empty() ? nullptr : password_.c_str()
             );
         }


### PR DESCRIPTION
The Qt code had interpreted the core code inversely with regard to folder recreation on extracting. This patch fixes the mistake and checks "Re-create folders" by default.

Fixes https://github.com/lxqt/lxqt-archiver/issues/434