### PR TITLE
Fixed handling of wrong passwords with 7z

### DIFF
--- a/src/core/fr-command-7z.c
+++ b/src/core/fr-command-7z.c
@@ -580,7 +580,8 @@ fr_command_7z_handle_error (FrCommand   *comm,
 			}
 		}
 
-		error->type = FR_PROC_ERROR_NONE; /* when error->status <= 1 */
+		if (error->status <= 1)
+			error->type = FR_PROC_ERROR_NONE;
 	}
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -743,6 +743,9 @@ void MainWindow::on_actionReload_triggered(bool /*checked*/) {
             QDir(tempDir_).removeRecursively();
         }
         password_.clear();
+        if(auto label = ui_->statusBar->findChild<QLabel*>()) {
+            label->clear();
+        }
         archiver_->reloadArchive(nullptr);
     }
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -69,6 +69,12 @@ MainWindow::MainWindow(QWidget* parent):
 
     loadSettings();
 
+    // use a label instead of QStatusBar::showMessage to make messages permanent
+    QLabel* label = new QLabel();
+    label->setFocusPolicy(Qt::NoFocus);
+    label->setContentsMargins(4, 0, 4, 0);
+    ui_->statusBar->addWidget(label);
+
     // create a progress bar in the status bar
     progressBar_ = new QProgressBar{ui_->statusBar};
     ui_->statusBar->addPermanentWidget(progressBar_);
@@ -966,6 +972,9 @@ void MainWindow::onActionFinished(FrAction action, ArchiverError err) {
             }
             Fm::FileLauncher().launchPaths(this, std::move(paths));
         }
+        else {
+            password_.clear(); // the password may have been wrong
+        }
         launchPaths_.clear();
         break;
     case FR_ACTION_COPYING_FILES_TO_REMOTE:    /* copying extracted files to a remote location */
@@ -982,7 +991,9 @@ void MainWindow::onActionFinished(FrAction action, ArchiverError err) {
 }
 
 void MainWindow::onMessage(QString message) {
-    ui_->statusBar->showMessage(message);
+    if(auto label = ui_->statusBar->findChild<QLabel*>()) {
+        label->setText(message);
+    }
 }
 
 void MainWindow::onStoppableChanged(bool stoppable) {
@@ -1099,7 +1110,9 @@ void MainWindow::showFileList(const std::vector<const ArchiverItem *> &files) {
 
     proxyModel_->setSourceModel(model);
 
-    ui_->statusBar->showMessage(tr("%n file(s)", "", files.size()));
+    if(auto label = ui_->statusBar->findChild<QLabel*>()) {
+        label->setText(tr("%n file(s)", "", files.size()));
+    }
 
     fitFileViewColumns();
 }


### PR DESCRIPTION
An error was skipped by mistake.

Also made the messages of the status-bar permanent. Previously, they disappeared on moving the cursor over a menu-bar item.

Fixes https://github.com/lxqt/lxqt-archiver/issues/429