### PR TITLE
Showed overwrite option in password dialog with "Extract Here"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -291,7 +291,12 @@ static int runApp(QApplication& app) {
                     if(action == FR_ACTION_LISTING_CONTENT
                        && err.type() == FR_PROC_ERROR_ASK_PASSWORD
                        && password_.empty()) { // encrypted list
-                        password_ = PasswordDialog::askPassword().toStdString();
+                        if(extract_to || extract_here) {
+                            password_ = PasswordDialog::askPasswordAndOverwrite(extractOverwrite).toStdString();
+                        }
+                        else {
+                            password_ = PasswordDialog::askPassword().toStdString();
+                        }
                         if(!password_.empty()) {
                             archiver.reloadArchive(password_.c_str());
                             return;
@@ -304,7 +309,12 @@ static int runApp(QApplication& app) {
                 switch(action) {
                 case FR_ACTION_LISTING_CONTENT: {            /* loading the archive from a remote location */
                     if(archiver.isEncrypted() && password_.empty()) {
-                        password_ = PasswordDialog::askPassword().toStdString();
+                        if(extract_to || extract_here) {
+                            password_ = PasswordDialog::askPasswordAndOverwrite(extractOverwrite).toStdString();
+                        }
+                        else {
+                            password_ = PasswordDialog::askPassword().toStdString();
+                        }
                     }
 
                     if(extract_here) {

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -70,6 +70,7 @@ QString PasswordDialog::askPasswordAndOverwrite(bool& overwrite, QWidget* parent
     dlg.setWindowTitle(tr("Password"));
     QLabel *label = new QLabel(tr("Password:"));
     QLineEdit *le = new QLineEdit();
+    le->setEchoMode(QLineEdit::Password);
     QCheckBox *check = new QCheckBox(tr("Overwrite existing files"));
     QDialogButtonBox *btns = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     QObject::connect(btns, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);

--- a/src/passworddialog.cpp
+++ b/src/passworddialog.cpp
@@ -60,3 +60,38 @@ QString PasswordDialog::askPassword(QWidget* parent) {
     return QInputDialog::getText(parent, tr("Password"), tr("Password:"), QLineEdit::Password);
 }
 
+// static
+// NOTE: This password dialog is made especially for RAR files without an extraction dialog,
+// because 7z neither extracts them nor shows any error when there are empty or incomplete
+// extracted files, but the extraction will succeed with a correct password if files are
+// overwritten. However, it can be used anywhere no extraction dialog is shown.
+QString PasswordDialog::askPasswordAndOverwrite(bool& overwrite, QWidget* parent) {
+    QDialog dlg(parent);
+    dlg.setWindowTitle(tr("Password"));
+    QLabel *label = new QLabel(tr("Password:"));
+    QLineEdit *le = new QLineEdit();
+    QCheckBox *check = new QCheckBox(tr("Overwrite existing files"));
+    QDialogButtonBox *btns = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    QObject::connect(btns, &QDialogButtonBox::accepted, &dlg, &QDialog::accept);
+    QObject::connect(btns, &QDialogButtonBox::rejected, &dlg, &QDialog::reject);
+    QVBoxLayout *layout = new QVBoxLayout;
+    layout->addWidget(label);
+    layout->addWidget(le);
+    layout->addWidget(check);
+    layout->addWidget(btns);
+    dlg.setLayout(layout);
+    dlg.setMaximumHeight(dlg.minimumSizeHint().height()); // no vertical resizing
+    le->setFocus(); // needed with Qt >= 6.6.1
+
+    QString psswrd;
+    switch (dlg.exec()) {
+    case QDialog::Accepted:
+        psswrd = le->text();
+        overwrite = check->isChecked();
+        break;
+    default:
+        break;
+    }
+
+    return psswrd;
+}

--- a/src/passworddialog.h
+++ b/src/passworddialog.h
@@ -36,22 +36,23 @@ class PasswordDialog : public QDialog {
 public:
 
     PasswordDialog(QWidget* parent = nullptr);
-    
+
     ~PasswordDialog();
 
     QString password() const;
 
     void setPassword(const QString& password);
-    
+
     void setEncryptFileList(bool value);
 
     bool encryptFileList() const;
 
     static QString askPassword(QWidget* parent = nullptr);
+    static QString askPasswordAndOverwrite(bool& overwrite, QWidget* parent = nullptr);
 
 private Q_SLOTS:
     void onTogglePassword(bool toggled);
-    
+
 private:
     std::unique_ptr<Ui::PasswordDialog> ui_;
 };


### PR DESCRIPTION
This is especially for bypassing a problem of 7z with password-protected RAR archives.

Closes https://github.com/lxqt/lxqt-archiver/issues/437

NOTE: Although no new translatable string is added, translations need to be updated.