### PR TITLE
lha: Fix crash, parse lha list output correctly

### DIFF
--- a/src/core/fr-command-lha.c
+++ b/src/core/fr-command-lha.c
@@ -96,7 +96,7 @@ static char **
 split_line_lha (char *line)
 {
 	char       **fields;
-	int          n_fields = 7;
+	int          n_fields = 8;
 	const char  *scan, *field_end;
 	int          i;
 
@@ -105,66 +105,48 @@ split_line_lha (char *line)
 
 	i = 0;
 
-	if (strncmp (line, "[MS-DOS]", 8) == 0) {
-		fields[i++] = g_strdup ("");
-		fields[i++] = g_strdup ("");
-		line += strlen ("[MS-DOS]");
-	}
-	else if (strncmp (line, "[generic]", 9) == 0) {
-		fields[i++] = g_strdup ("");
-		fields[i++] = g_strdup ("");
-		line += strlen ("[generic]");
-	}
-	else if (strncmp (line, "[unknown]", 9) == 0) {
-		fields[i++] = g_strdup ("");
-		fields[i++] = g_strdup ("");
-		line += strlen ("[unknown]");
-	}
-	else if (strncmp (line, "[Amiga]", 7) == 0) {
-		fields[i++] = g_strdup ("");
-		fields[i++] = g_strdup ("");
-		line += strlen ("[Amiga]");
+	/* First column either contains Unix permissions or OS type, depending
+	 * on what generated the archive. The OS type is enclosed in [brackets]
+	 * and may include a space. */
+	scan = eat_spaces (line);
+	if (scan[0] == '[') {
+		field_end = strchr (scan, ']');
+		if (field_end != NULL) {
+			++field_end;
+		}
+	} else {
+		field_end = NULL;
 	}
 
-	scan = eat_spaces (line);
-	for (; i < n_fields; i++) {
+	if (field_end == NULL) {
 		field_end = strchr (scan, ' ');
-		if (field_end != NULL) {
-			fields[i] = g_strndup (scan, field_end - scan);
-			scan = eat_spaces (field_end);
+		if (field_end == NULL) {
+			field_end = scan + strlen(scan);
 		}
 	}
 
-	return fields;
-}
+	fields[i++] = g_strndup (scan, field_end - scan);
+	scan = field_end;
 
-
-static const char *
-get_last_field_lha (char *line)
-{
-	int         i;
-	const char *field;
-	int         n = 7;
-
-	if (strncmp (line, "[MS-DOS]", 8) == 0)
-		n--;
-
-	if (strncmp (line, "[generic]", 9) == 0)
-		n--;
-
-	if (strncmp (line, "[unknown]", 9) == 0)
-		n--;
-
-	if (strncmp (line, "[Amiga]", 7) == 0)
-		n--;
-
-	field = eat_spaces (line);
-	for (i = 0; i < n; i++) {
-		field = strchr (field, ' ');
-		field = eat_spaces (field);
+	/* Second column contains Unix UID/GID, but if the archive was not
+	 * made on a Unix system it will be empty. Insert a dummy value so
+	 * we get a consistent result. */
+	if (g_str_has_prefix (scan, "           ")) {
+		fields[i++] = g_strdup("");
 	}
 
-	return field;
+	scan = eat_spaces (scan);
+	for (; i < n_fields; i++) {
+		field_end = strchr (scan, ' ');
+		if (field_end == NULL) {
+			field_end = scan + strlen(scan);
+		}
+
+		fields[i] = g_strndup (scan, field_end - scan);
+		scan = eat_spaces (field_end);
+	}
+
+	return fields;
 }
 
 
@@ -186,11 +168,10 @@ process_line (char     *line,
 	fdata->modified = mktime_from_string (fields[4],
 					      fields[5],
 					      fields[6]);
-	g_strfreev (fields);
 
 	/* Full path */
 
-	name_field = get_last_field_lha (line);
+	name_field = fields[7];
 
 	if (name_field && *name_field == '/') {
 		fdata->full_path = g_strdup (name_field);
@@ -199,6 +180,8 @@ process_line (char     *line,
 		fdata->full_path = g_strconcat ("/", name_field, NULL);
 		fdata->original_path = fdata->full_path + 1;
 	}
+
+	g_strfreev (fields);
 
 	fdata->link = NULL;
 


### PR DESCRIPTION
The output from the `lha` list archive command is eclectic and inconsistent, and lxqt-archiver was actually crashing when opening certain archives (eg. lha_x68k_213/h1_lh5.lzh in the Lhasa test suite). But this also fixes the list parsing more generally. With this change, lxqt-archiver now appears to successfully open all of the .lzh files in the Lhasa test suite correctly without crashing.

The first field in lha's list output either contains Unix permissions or an OS name in [brackets]. There was already hard-coded support for [MS-DOS], [generic], [unknown] and [Amiga], but other OS names were not handled properly. This is now fixed, with an approach that is mindful of the fact that the OS name can contain spaces.

Empty value (whitespace) in the UID/GID column is also handled correctly.  This was partially working because of the aforementioned special-casing, but now is fixed more generally.

The same fix has already been applied to Gnome's file-roller: <https://gitlab.gnome.org/GNOME/file-roller/-/commit/da87a02d17ff3ce82796c35dd94abf7229277941>