### PR TITLE
Disable context menu actions and Del shortcut if zero files

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -464,13 +464,18 @@ void MainWindow::on_actionAddFolder_triggered(bool /*checked*/) {
 }
 
 void MainWindow::on_actionDelete_triggered(bool /*checked*/) {
-    if(QMessageBox::question(this, tr("Confirm"), tr("Are you sure you want to delete selected files?"), QMessageBox::Yes|QMessageBox::No) != QMessageBox::Yes) {
-        return;
-    }
-    //qDebug("delete");
-    auto files = selectedFiles(true);
-    if(!files.empty()) {
-        archiver_->removeFiles(files, FR_COMPRESSION_NORMAL);
+    // to prevent Del shortcut
+    if(ui_->fileListView->selectionModel()->hasSelection())
+    {
+        if(QMessageBox::question(this, tr("Confirm"), tr("Are you sure you want to delete selected files?"),
+                                 QMessageBox::Yes|QMessageBox::No) != QMessageBox::Yes) {
+            return;
+        }
+        //qDebug("delete");
+        auto files = selectedFiles(true);
+        if(!files.empty()) {
+            archiver_->removeFiles(files, FR_COMPRESSION_NORMAL);
+        }
     }
 }
 
@@ -787,6 +792,8 @@ void MainWindow::onFileListContextMenu(const QPoint &pos) {
         QModelIndex idx = selModel->currentIndex();
         auto item = itemFromIndex(idx);
         ui_->actionView->setVisible(item && !item->isDir());
+        ui_->actionDelete->setEnabled(selModel->hasSelection());
+        ui_->actionView->setEnabled(selModel->hasSelection());
     }
     // QAbstractScrollArea and its subclasses map the context menu event to coordinates of the viewport().
     auto globalPos = ui_->fileListView->viewport()->mapToGlobal(pos);


### PR DESCRIPTION
File list→Delete deletes the currently selected file(s), thus is only actionable when >0 files are selected. Same for File list→View Selected Files for viewing. Also handle the Del shortcut.
