### PR TITLE
Use the correct path in dirByPath

### DIFF
--- a/src/archiver.cpp
+++ b/src/archiver.cpp
@@ -534,7 +534,7 @@ const ArchiverItem *Archiver::dirByPath(const char *path) const {
     if(dirPath.length() > 1 && dirPath.back() == '/') {
         dirPath.pop_back();
     }
-    auto it = dirMap_.find(path);
+    auto it = dirMap_.find(dirPath);
     return it != dirMap_.end() ? it->second : nullptr;
 }
 


### PR DESCRIPTION
This fixes #450

Seems like the expected behaviour WAS to really stay in the correct folder, as seen in mainwindow.cpp:
<img width="1556" height="584" alt="grafik" src="https://github.com/user-attachments/assets/8b2b07a5-a2b0-4bbf-a552-b3f620ab3e79" />
Path wasn't being found due to a small typo ig.