### PR TITLE
Set window icon

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -368,6 +368,7 @@ int main(int argc, char** argv) {
 
     QApplication app(argc, argv);
     app.setApplicationVersion(QStringLiteral(LXQT_ARCHIVER_VERSION));
+    app.setWindowIcon(QIcon::fromTheme(QStringLiteral("lxqt-archiver")));
     app.setQuitOnLastWindowClosed(true);
 
     // load translations


### PR DESCRIPTION
This ensures that the icon is set on all windows on X11.

Without this, the window icon is missing when the extract/archive dialog is invoked directly:
```
$ lxqt-archiver --add-to=<filename>
$ lxqt-archiver --extract-to=<filename>
```