### PR TITLE
Enable the Stop action only when something is in progress

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1190,6 +1190,7 @@ void MainWindow::setBusyState(bool busy) {
 void MainWindow::updateUiStates() {
     bool hasArchive = archiver_->isLoaded();
     bool inProgress = archiver_->isBusy();
+    ui_->actionStop->setEnabled(inProgress);
 
     bool canLoad = !hasArchive || !inProgress;
     ui_->actionCreateNew->setEnabled(canLoad);


### PR DESCRIPTION
Enable the Stop action only when there is something in progress.

Previously it was always enabled (even with no archive opened.)