### PR TITLE
Fix some core C code warnings

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -4,6 +4,9 @@ include_directories(
     ${CMAKE_BINARY_DIR}
 )
 
+# We use GNU extensions
+set(CMAKE_C_EXTENSIONS ON)
+
 add_library(lxqt-archiver-core STATIC
     tr-wrapper.c  # our own wrapper for QTranslater
     file-data.c


### PR DESCRIPTION
The code is correct.
Setting the C standard(https://github.com/lxqt/lxqt-build-tools/pull/113)
and extensions does the job.

Fixes https://github.com/lxqt/lxqt-archiver/issues/468.
